### PR TITLE
Added feature to override http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,8 @@ In order to add a proxy to the HTTP request we can extend `Net::HTTP` through th
 
 ```ruby
 class ZCRMSDK::HTTPClient < Net::HTTP
-  def initialize(host, port)
-    if proxy_host.present?
-      super(host, port, proxy_host, proxy_port, proxy_username, proxy_password)
-    end
-  end
-
-  private
-
-  def proxy_host
-    ....
+  def self.new(host, port)
+    super(host, port, proxy_host, proxy_port, proxy_username, proxy_password)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ To fully install the CRM API wrapper yourself, just execute this command:
 In order to add a proxy to the HTTP request we can extend `Net::HTTP` through the `ZCRMSDK::HTTPClient`
 
 ```ruby
-class ZCRMSDK::HTTPClient < Net::HTTP
+class ZCRMSDK::HTTPClient
   def self.new(host, port)
-    super(host, port, proxy_host, proxy_port, proxy_username, proxy_password)
+    Net::HTTP.new(host, port, proxy_host, proxy_port, proxy_username, proxy_password)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The Ruby library for integrating with the Zoho CRM API.
 
-
 ## Installation
 
 There are a couple of ways of installing ZCRMSDKK:
@@ -11,26 +10,44 @@ Install 1:
 
 Start by adding this line to your application's Gemfile:
 
-  gem 'ZCRMSDK'
+gem 'ZCRMSDK'
 
 And follow it with executing this command:
 
-  $ bundle
+\$ bundle
 
 Install 2:
 
 To fully install the CRM API wrapper yourself, just execute this command:
 
-  $ gem install ZCRMSDK
-
+\$ gem install ZCRMSDK
 
 ## Documentation
 
 ### <a href="https://www.zoho.com/crm/developer/docs/server-side-sdks/ruby.html" rel="nofollow">SDK documentation</a>
+
 ### <a href="https://www.zoho.com/crm/developer/docs/api/overview.html" rel="nofollow">API Reference</a>
 
 ## Usage
 
 ### Refer <a href="https://www.zoho.com/crm/developer/docs/server-side-sdks/ruby.html" rel="nofollow">SDK documentation</a> for Usage
 
+### Overriding HTTP client
 
+In order to add a proxy to the HTTP request we can extend `Net::HTTP` through the `ZCRMSDK::HTTPClient`
+
+```ruby
+class ZCRMSDK::HTTPClient < Net::HTTP
+  def initialize(host, port)
+    if proxy_host.present?
+      super(host, port, proxy_host, proxy_port, proxy_username, proxy_password)
+    end
+  end
+
+  private
+
+  def proxy_host
+    ....
+  end
+end
+```

--- a/lib/ZCRMSDK.rb
+++ b/lib/ZCRMSDK.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ZCRMSDK/http_client'
 require 'ZCRMSDK/oauth_utility'
 require 'ZCRMSDK/operations'
 require 'ZCRMSDK/handler'

--- a/lib/ZCRMSDK/http_client.rb
+++ b/lib/ZCRMSDK/http_client.rb
@@ -1,0 +1,6 @@
+require 'net/http'
+
+module ZCRMSDK
+  class HTTPClient < Net::HTTP
+  end
+end

--- a/lib/ZCRMSDK/http_client.rb
+++ b/lib/ZCRMSDK/http_client.rb
@@ -1,6 +1,9 @@
 require 'net/http'
 
 module ZCRMSDK
-  class HTTPClient < Net::HTTP
+  class HTTPClient
+    def self.new(*args)
+      Net::HTTP.new(*args)
+    end
   end
 end

--- a/lib/ZCRMSDK/oauth_utility.rb
+++ b/lib/ZCRMSDK/oauth_utility.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logger'
-require 'net/http'
 require_relative 'utility'
 module ZCRMSDK
   module OAuthUtility
@@ -101,12 +100,12 @@ module ZCRMSDK
           @url += '?' + query_string
         end
         url = URI(@url)
-        http = Net::HTTP.new(url.host, url.port)
+        http = HTTPClient.new(url.host, url.port)
         http.use_ssl = true
         if @req_method == OAuthUtility::ZohoOAuthConstants::REQUEST_METHOD_GET
-          req = Net::HTTP::Get.new(url.request_uri)
+          req = HTTPClient::Get.new(url.request_uri)
         elsif @req_method == OAuthUtility::ZohoOAuthConstants::REQUEST_METHOD_POST
-          req = Net::HTTP::Post.new(url.request_uri)
+          req = HTTPClient::Post.new(url.request_uri)
         end
         unless @req_headers.nil?
           @req_headers.each do |key, value|

--- a/lib/ZCRMSDK/oauth_utility.rb
+++ b/lib/ZCRMSDK/oauth_utility.rb
@@ -103,9 +103,9 @@ module ZCRMSDK
         http = HTTPClient.new(url.host, url.port)
         http.use_ssl = true
         if @req_method == OAuthUtility::ZohoOAuthConstants::REQUEST_METHOD_GET
-          req = HTTPClient::Get.new(url.request_uri)
+          req = Net::HTTP::Get.new(url.request_uri)
         elsif @req_method == OAuthUtility::ZohoOAuthConstants::REQUEST_METHOD_POST
-          req = HTTPClient::Post.new(url.request_uri)
+          req = Net::HTTP::Post.new(url.request_uri)
         end
         unless @req_headers.nil?
           @req_headers.each do |key, value|

--- a/lib/ZCRMSDK/utility.rb
+++ b/lib/ZCRMSDK/utility.rb
@@ -227,18 +227,18 @@ module ZCRMSDK
         http = HTTPClient.new(url.host, url.port)
         http.use_ssl = true
         if @req_method == APIConstants::REQUEST_METHOD_GET
-          req = HTTPClient::Get.new(url.request_uri)
+          req = Net::HTTP::Get.new(url.request_uri)
         elsif @req_method == APIConstants::REQUEST_METHOD_POST
-          req = HTTPClient::Post.new(url.request_uri)
+          req = Net::HTTP::Post.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_PUT
-          req = HTTPClient::Put.new(url.request_uri)
+          req = Net::HTTP::Put.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_PATCH
-          req = HTTPClient::Patch.new(url.request_uri)
+          req = Net::HTTP::Patch.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_DELETE
-          req = HTTPClient::Delete.new(url.request_uri)
+          req = Net::HTTP::Delete.new(url.request_uri)
         end
         @req_headers.each { |key, value| req.add_field(key, value) }
         unless @req_form_data.nil?

--- a/lib/ZCRMSDK/utility.rb
+++ b/lib/ZCRMSDK/utility.rb
@@ -6,7 +6,6 @@ require_relative 'restclient'
 require 'uri'
 require 'json'
 require 'logger'
-require 'net/http'
 require 'cgi'
 module ZCRMSDK
   module Utility
@@ -225,21 +224,21 @@ module ZCRMSDK
           @url += '?' + query_string
         end
         url = URI(@url)
-        http = Net::HTTP.new(url.host, url.port)
+        http = HTTPClient.new(url.host, url.port)
         http.use_ssl = true
         if @req_method == APIConstants::REQUEST_METHOD_GET
-          req = Net::HTTP::Get.new(url.request_uri)
+          req = HTTPClient::Get.new(url.request_uri)
         elsif @req_method == APIConstants::REQUEST_METHOD_POST
-          req = Net::HTTP::Post.new(url.request_uri)
+          req = HTTPClient::Post.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_PUT
-          req = Net::HTTP::Put.new(url.request_uri)
+          req = HTTPClient::Put.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_PATCH
-          req = Net::HTTP::Patch.new(url.request_uri)
+          req = HTTPClient::Patch.new(url.request_uri)
           req.body = @req_body.to_s
         elsif @req_method == APIConstants::REQUEST_METHOD_DELETE
-          req = Net::HTTP::Delete.new(url.request_uri)
+          req = HTTPClient::Delete.new(url.request_uri)
         end
         @req_headers.each { |key, value| req.add_field(key, value) }
         unless @req_form_data.nil?


### PR DESCRIPTION
Hello,

We have been trying to configure an HTTP Proxy in order to send API request through a specific IP, unfortunately it was not quite so simple to override the current behaviour. We have proposed an improvement that would allow overriding the default HTTP Client.
